### PR TITLE
Showing binary and hex in a more friendly way

### DIFF
--- a/convertBinary.py
+++ b/convertBinary.py
@@ -18,7 +18,7 @@ o = alp.Item(**octalDic)
 
 
 # calculate hex number
-hexadec = hex(decimal)[2:]
+hexadec = hex(decimal)[2:].upper()
 # create associative array and create xml from it
 hexDic = dict(title=str(hexadec), subtitle="Hexadecimal", uid="hex", valid=True, arg=str(hexadec), icon="icons/hex.png")
 h = alp.Item(**hexDic)

--- a/convertDecimal.py
+++ b/convertDecimal.py
@@ -4,7 +4,7 @@ import sys
 import alp
 
 # calculate binary number
-binary = bin(int(sys.argv[1]))[2:]
+binary = bin(int(sys.argv[1]))[2:].zfill(8)
 # create associative array and create xml from it
 binaryDic = dict(title=str(binary), subtitle="Binary", uid="binary", valid=True, arg=str(binary), icon="icons/binary.png")
 b = alp.Item(**binaryDic)
@@ -17,7 +17,7 @@ o = alp.Item(**octalDic)
 
 
 # calculate hex number
-hexadec = hex(int(sys.argv[1]))[2:]
+hexadec = hex(int(sys.argv[1]))[2:].upper()
 # create associative array and create xml from it
 hexDic = dict(title=str(hexadec), subtitle="Hexadecimal", uid="hex", valid=True, arg=str(hexadec), icon="icons/hex.png")
 h = alp.Item(**hexDic)

--- a/convertHex.py
+++ b/convertHex.py
@@ -11,7 +11,7 @@ d = alp.Item(**decimalDic)
 
 
 # calculate binary number
-binary = bin(decimal)[2:]
+binary = bin(decimal)[2:].zfill(8)
 # create associative array and create xml from it
 binaryDic = dict(title=str(binary), subtitle="Binary", uid="binary", valid=True, arg=str(binary), icon="icons/binary.png")
 b = alp.Item(**binaryDic)

--- a/convertOctal.py
+++ b/convertOctal.py
@@ -11,14 +11,14 @@ d = alp.Item(**decimalDic)
 
 
 # calculate binary number
-binary = bin(decimal)[2:]
+binary = bin(decimal)[2:].zfill(8)
 # create associative array and create xml from it
 binaryDic = dict(title=str(binary), subtitle="Binary", uid="binary", valid=True, arg=str(binary), icon="icons/binary.png")
 b = alp.Item(**binaryDic)
 
 
 # calculate hex number
-hexadec = hex(decimal)[2:]
+hexadec = hex(decimal)[2:].upper()
 # create associative array and create xml from it
 hexDic = dict(title=str(hexadec), subtitle="Hexadecimal", uid="hex", valid=True, arg=str(hexadec), icon="icons/hex.png")
 h = alp.Item(**hexDic)


### PR DESCRIPTION
Binary output is prefilled with 0's (up to one byte), hex is always uppercase. Makes it nicer to copy-paste into code
