### PR TITLE
Add 2's complement negative support

### DIFF
--- a/alp/__init__.py
+++ b/alp/__init__.py
@@ -1,4 +1,5 @@
 from .core import *
+from .tc import *
 
 try:
     from .item import *

--- a/alp/tc.py
+++ b/alp/tc.py
@@ -1,0 +1,25 @@
+def decimal2negative(n):
+    """
+        We convert a decimal number into a negative based on the 2's complement.
+        As an example for an arbitrary decimal larger than 1:
+
+           0101         (binary for decimal 5)
+        -> 101          (trim the zeros before the most significant bit)
+        -> -(2^2)+2^0   (convert binary into decimal under the 2's complment principle)
+        -> -3           (result)
+    """
+    if (n <= 1):
+        return 0
+
+    nn = n
+    bias = 1
+    msb = 0
+    n = int(n / 2)
+
+    while (n > 0):
+        n = int(n / 2)
+        msb += 1
+        bias *= 2
+
+    return (((1 << msb) - 1) & nn) - bias
+

--- a/convertBinary.py
+++ b/convertBinary.py
@@ -24,4 +24,13 @@ hexDic = dict(title=str(hexadec), subtitle="Hexadecimal", uid="hex", valid=True,
 h = alp.Item(**hexDic)
 
 itemsList = [d, o, h]
+
+# calculate negative number
+tc = alp.decimal2negative(decimal)
+if (tc < 0):
+    # create associative array and create xml from it
+    tcDic = dict(title=str(tc), subtitle="2's complement negative after trimming the zeros before the most significant bit", uid="negative", valid=True, arg=str(tc), icon="icons/decimal.png")
+    t = alp.Item(**tcDic)
+    itemsList += [t]
+
 alp.feedback(itemsList)

--- a/convertDecimal.py
+++ b/convertDecimal.py
@@ -23,4 +23,13 @@ hexDic = dict(title=str(hexadec), subtitle="Hexadecimal", uid="hex", valid=True,
 h = alp.Item(**hexDic)
 
 itemsList = [b, o, h]
+
+# calculate negative number
+tc = alp.decimal2negative(int(sys.argv[1]))
+if (tc < 0):
+    # create associative array and create xml from it
+    tcDic = dict(title=str(tc), subtitle="2's complement negative after trimming the zeros before the most significant bit", uid="negative", valid=True, arg=str(tc), icon="icons/decimal.png")
+    t = alp.Item(**tcDic)
+    itemsList += [t]
+
 alp.feedback(itemsList)

--- a/convertHex.py
+++ b/convertHex.py
@@ -23,4 +23,13 @@ octalDic = dict(title=str(octal), subtitle="Octal", uid="octal", valid=True, arg
 o = alp.Item(**octalDic)
 
 itemsList = [d, b, o]
+
+# calculate negative number
+tc = alp.decimal2negative(decimal)
+if (tc < 0):
+    # create associative array and create xml from it
+    tcDic = dict(title=str(tc), subtitle="2's complement negative after trimming the zeros before the most significant bit", uid="negative", valid=True, arg=str(tc), icon="icons/decimal.png")
+    t = alp.Item(**tcDic)
+    itemsList += [t]
+
 alp.feedback(itemsList)

--- a/convertOctal.py
+++ b/convertOctal.py
@@ -24,4 +24,13 @@ hexDic = dict(title=str(hexadec), subtitle="Hexadecimal", uid="hex", valid=True,
 h = alp.Item(**hexDic)
 
 itemsList = [d, b, h]
+
+# calculate negative number
+tc = alp.decimal2negative(decimal)
+if (tc < 0):
+    # create associative array and create xml from it
+    tcDic = dict(title=str(tc), subtitle="2's complement negative after trimming the zeros before the most significant bit", uid="negative", valid=True, arg=str(tc), icon="icons/decimal.png")
+    t = alp.Item(**tcDic)
+    itemsList += [t]
+
 alp.feedback(itemsList)


### PR DESCRIPTION
#10 

This commit might not be well enough considered or complete.
- I added a function `decimal2negative` to convert a decimal larger than 1 into a negative decimal under the 2's complement principle with the zeros before the most significant bit trimmed.
- I displayed the result within the forth row when the given argument evaluated larger than decimal `1` for all convert scripts except for the "number convert".
- I reused the decimal icon.
- Also not well tested for extreme values.